### PR TITLE
Add optional BUNDLE_SUB_DIR

### DIFF
--- a/utils/generate-effective-bundles.sh
+++ b/utils/generate-effective-bundles.sh
@@ -21,6 +21,10 @@ loadDotenv() {
     fi
 }
 WORKSPACE="${WORKSPACE:-${PWD}}"
+if [ -n "$BUNDLE_SUB_DIR" ]; then
+    echo "INFO: Setting WORKSPACE to BUNDLE_SUB_DIR: ${WORKSPACE}/${BUNDLE_SUB_DIR}"
+    WORKSPACE="${WORKSPACE}/${BUNDLE_SUB_DIR}"
+fi
 loadDotenv
 
 # minimal tool versions
@@ -30,6 +34,10 @@ MIN_VER_YQ="4.35.2"
 ver() {
     echo "$@" | awk -F. '{ printf("%d%03d%03d", $1,$2,$3); }'
 }
+
+die() { echo "$*"; exit 1; }
+
+debug() { if [ "$DEBUG" -eq 1 ]; then echo "$*"; fi; }
 
 MD5SUM_EMPTY_STR=$(echo -n | md5sum | cut -d' ' -f 1)
 MINIMUM_PLUGINS_ERR="Minimum plugins error - you need at a minimum cloudbees-casc-client and cloudbees-casc-items-controller if using items"
@@ -75,10 +83,6 @@ if command -v cascdeps &> /dev/null; then
 elif [ -z "${DEP_TOOL:-}" ]; then
     DEP_TOOL="${PARENT_DIR}/run.sh"
 fi
-
-die() { echo "$*"; exit 1; }
-
-debug() { if [ "$DEBUG" -eq 1 ]; then echo "$*"; fi; }
 
 determineCIVersion() {
     CI_VERSION="${CI_VERSION:-}"


### PR DESCRIPTION
This PR adds an optional `BUNDLE_SUB_DIR` environment which allows placing bundles into sub directories whilst still running from the repository root.

For example, take the following directory structure:

```mono
❯ tree -a -I .git -I .gitignore --dirsfirst -L 2
.
├── .cache
│   ├── 2.426.1.3
│   ├── 2.426.2.1
│   ├── 2.426.2.2
│   └── 2.426.3.3
├── prod
│   ├── .cache
│   ├── effective-bundles
│   ├── raw-bundles
│   ├── target
│   ├── validation-bundles
│   └── .env
├── test
│   ├── .cache
│   ├── effective-bundles
│   ├── raw-bundles
│   ├── target
│   ├── validation-bundles
│   └── .env
├── .pre-commit-config.yaml
└── test-utils.sh
```

The `BUNDLE_SUB_DIR` option now allows us to have two pre-commit config, specifying a different sub directory each time.

For example:

```yaml
repos:
  - repo: local
    hooks:
      - id: check-effective-bundles-test
        name: check-effective-bundles-test
        entry: /usr/bin/env BUNDLE_SUB_DIR=test
        args: [cascgen, pre-commit]
        language: script
        pass_filenames: false
        verbose: false
        always_run: true
      - id: check-effective-bundles-prod
        name: check-effective-bundles-prod
        entry: /usr/bin/env BUNDLE_SUB_DIR=prod
        args: [cascgen, pre-commit]
        language: script
        pass_filenames: false
        verbose: false
        always_run: true
  - repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v4.4.0
    hooks:
      - id: check-yaml
        files: .*\.(yaml|yml)$
```

Running locally you would either cd into the directory in question, or use `BUNDLE_SUB_DIR=test cascgen ...`

